### PR TITLE
Update base.css

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -551,6 +551,6 @@ a:focus {
 		font-size: 0.857rem;
 		text-transform: uppercase;
 		font-weight: 500;
-		fill: var(--cursor-text);
+		color: var(--cursor-text);
 	}
 }


### PR DESCRIPTION
Switching CSS property as .cursor__text is a span not a text element of the cursor's svg